### PR TITLE
chore: correct code block language tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It injects the [locale code][3] of your pages in the base path of the URL, your 
 
 ## Configuration
 
-```.json
+```js
 {
     resolve: `gatsby-plugin-intl-url`,
     options: {
@@ -75,7 +75,7 @@ After handled by the plugin, the page's context have been injected with the foll
 ### Paths translation file
 
 This file must be structured as follows:
-```.json
+```json
 {
     "fr": {
         "slugs": {


### PR DESCRIPTION
This is to silence prism highlighter warnings. Thanks!